### PR TITLE
v1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
   endif()
 endif()
 
+## Do an out-of-source build
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 ## Check dependencies
 ### OpenMP
 find_package(OpenMP)
@@ -65,7 +69,7 @@ if (MPI_FOUND)
       message(FATAL_ERROR "Build step for BigMPI failed: ${result}")
     endif()
     set(CMAKE_BIGMPI_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/src)
-    set(CMAKE_BIGMPI_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/build/src/libbigmpi.a)
+    set(CMAKE_BIGMPI_LIBRARY ${LIBRARY_OUTPUT_PATH}/libbigmpi.a)
     add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi
       ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/build)
   endif()
@@ -81,10 +85,6 @@ if (${CMAKE_MAJOR_VERSION} GREATER 2 AND ${CMAKE_MINOR_VERSION} GREATER 0)
 else()
   add_compile_options(-std=c++11)
 endif()
-
-## Do an out-of-source build
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 ## Get version number from git tags
 find_package(Git)
@@ -186,7 +186,7 @@ endif()
 # Link libraries
 if (OPENMP_FOUND)
   if (MPI_FOUND)
-    target_link_libraries(rcgmpi OpenMP::OpenMP_CXX ${CMAKE_BIGMPI_LIBRARY}) ## Hybrid parallellization
+    target_link_libraries(rcgmpi OpenMP::OpenMP_CXX ${LIBRARY_OUTPUT_PATH}/libbigmpi.a) ## Hybrid parallellization
   endif()
   if (BUILD_TESTS)
     target_link_libraries(rcgomp rcgutils runUnitTests OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ if (MPI_FOUND)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/rcgpar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Matrix_omp.cpp)
   target_link_libraries(rcgmpi rcgutils)
+  add_dependencies(rcgmpi bigmpi)
   ## Unit tests
   if(CMAKE_BUILD_TESTS)
     target_link_libraries(runMpiTest rcgmpi gtest gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,33 @@ if (MPI_FOUND)
   else()
     set(RCGPAR_MPI_MAX_PROCESSES 1024)
   endif()
+
+  # Check MPI dependencies
+  ## BigMPI
+  if (DEFINED CMAKE_BIGMPI_HEADERS AND DEFINED CMAKE_BIGMPI_LIBRARY)
+    message(STATUS "BigMPI headers provided in: ${CMAKE_BIGMPI_HEADERS}")
+    message(STATUS "BigMPI library provided in: ${CMAKE_BIGMPI_LIBRARY}")
+  else()
+    set(LIB_LINKAGE_TYPE "STATIC")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/CMakeLists-bigmpi.txt.in ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi-download/CMakeLists.txt)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi-download )
+    if(result)
+      message(FATAL_ERROR "CMake step for BigMPI failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi-download )
+    if(result)
+      message(FATAL_ERROR "Build step for BigMPI failed: ${result}")
+    endif()
+    set(CMAKE_BIGMPI_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/src)
+    set(CMAKE_BIGMPI_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/build/src/libbigmpi.a)
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi
+      ${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi/build)
+  endif()
+  include_directories("${CMAKE_BIGMPI_HEADERS}")
 else()
   set(RCGPAR_MPI_SUPPORT 0)
 endif()
@@ -159,7 +186,7 @@ endif()
 # Link libraries
 if (OPENMP_FOUND)
   if (MPI_FOUND)
-    target_link_libraries(rcgmpi OpenMP::OpenMP_CXX) ## Hybrid parallellization
+    target_link_libraries(rcgmpi OpenMP::OpenMP_CXX ${CMAKE_BIGMPI_LIBRARY}) ## Hybrid parallellization
   endif()
   if (BUILD_TESTS)
     target_link_libraries(rcgomp rcgutils runUnitTests OpenMP::OpenMP_CXX)

--- a/config/CMakeLists-bigmpi.txt.in
+++ b/config/CMakeLists-bigmpi.txt.in
@@ -9,7 +9,7 @@ ExternalProject_Add(bigmpi-download
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi"
   BUILD_IN_SOURCE   0
   BUILD_COMMAND	    ""
-  CMAKE_ARGS	    -D LIB_LINKAGE_TYPE="STATIC"
+  CMAKE_ARGS	    ""
   CONFIGURE_COMMAND ""
   INSTALL_COMMAND   ""
   TEST_COMMAND      ""

--- a/config/CMakeLists-bigmpi.txt.in
+++ b/config/CMakeLists-bigmpi.txt.in
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(bigmpi-get NONE)
+include(ExternalProject)
+
+ExternalProject_Add(bigmpi-download
+  GIT_REPOSITORY    https://github.com/jeffhammond/BigMPI
+  GIT_TAG           3107abb811d2785a7b1f101ac5722de78f354704
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external/bigmpi"
+  BUILD_IN_SOURCE   0
+  BUILD_COMMAND	    ""
+  CMAKE_ARGS	    -D LIB_LINKAGE_TYPE="STATIC"
+  CONFIGURE_COMMAND ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  UPDATE_COMMAND    ""
+)

--- a/config/mpi_config.hpp.in
+++ b/config/mpi_config.hpp.in
@@ -27,6 +27,7 @@
 #if defined(RCGPAR_MPI_SUPPORT) && (RCGPAR_MPI_SUPPORT) == 1
 #define OMPI_SKIP_MPICXX 1 // See https://github.com/open-mpi/ompi/issues/5157
 #include <mpi.h>
+#include "bigmpi.h"
 #endif
 
 #endif

--- a/src/rcgpar.cpp
+++ b/src/rcgpar.cpp
@@ -145,7 +145,7 @@ Matrix<double> rcg_optl_mpi(const Matrix<double> &logl_full, const std::vector<d
     for (uint16_t i = 0; i < n_groups; ++i) {
 	MPI_Gatherv(&gamma_Z_partial.front() + i*n_obs_per_task, n_obs_per_task, MPI_DOUBLE, &gamma_Z_full.front() + i*n_obs, sendcounts, displs, MPI_DOUBLE, 0, MPI_COMM_WORLD);
     }
-    MPI_Bcast(&gamma_Z_full.front(), n_groups*n_obs, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    MPIX_Bcast_x(&gamma_Z_full.front(), n_groups*n_obs, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
     return(gamma_Z_full);
 }


### PR DESCRIPTION
# rcgpar-v1.0.1
## Bug fixes
- Use the [BigMPI](https://github.com/jeffhammond/BigMPI) library to handle input data with dimensions exceeding the capacity of MPI_INT (32 bit signed integer) to store (fixes #1).

## Build pipeline
- Do an out-of-source build.